### PR TITLE
add an option to attempt a reload of a cache file during parse_query,…

### DIFF
--- a/include/turretClient.h
+++ b/include/turretClient.h
@@ -83,6 +83,8 @@ namespace turret_client
             bool m_cacheToDisk; // set by env var $TURRET_CLIENTID_CACHE_TO_DISK=1, default is false
             bool m_resolveFromFileCache; // set by env var $TURRET_CLIENTID_CACHE_LOCATION=/path/to/cache
             bool m_allowLiveResolves; // set by env var $TURRET_CLIENTID_ALLOW_LIVE_RESOLVES
+            bool m_cacheLoaded;
+            bool m_retryCacheLoad;
             std::string m_sessionID; // set by $TURRET_SESSION_ID=uuid
             std::string m_cacheFilePath;
             std::string m_cacheDir;

--- a/package.py
+++ b/package.py
@@ -2,7 +2,7 @@
 
 name = 'turret_lib'
 
-version = '1.1.22'
+version = '1.2.0'
 
 authors = [ 'ben.skinner',
             'daniel.flood'
@@ -17,9 +17,9 @@ build_requires = [
 ]
 
 variants = [
-   ['platform-linux', 'arch-x86_64', 'tbb-4', 'boost-1.55'],
-   ['platform-linux', 'arch-x86_64', 'tbb-2019', 'boost-1.55'],
-    ['platform-linux', 'arch-x86_64', 'tbb_katana-2017', 'boost_katana-1.61'],
+  ['platform-linux', 'arch-x86_64', 'tbb-4', 'boost-1.55'],
+  ['platform-linux', 'arch-x86_64', 'tbb-2019', 'boost-1.55'],
+  ['platform-linux', 'arch-x86_64', 'tbb_katana-2017', 'boost_katana-1.61'],
 ]
 
 def commands():

--- a/src/turretClient.cpp
+++ b/src/turretClient.cpp
@@ -179,8 +179,7 @@ namespace turret_client {
         }
 
         // use env var value to determine whether live resolves are allowed
-        if (const char *allowLiveResolves = std::getenv(
-                ("TURRET_" + clientIDUppercase + "_ALLOW_LIVE_RESOLVES").c_str())) {
+        if (const char *allowLiveResolves = std::getenv(("TURRET_" + clientIDUppercase + "_ALLOW_LIVE_RESOLVES").c_str())) {
             m_allowLiveResolves = std::stoi(allowLiveResolves);
 
             if (m_allowLiveResolves) {
@@ -378,12 +377,31 @@ namespace turret_client {
             m_cachedQueries.insert(std::make_pair(query, cache));
         }
 
+        m_cacheLoaded = true;
+
         fs.close();
 
         return true;
     }
 
     std::string turretClient::parse_query(const std::string &a_query) {
+
+        std::string clientIDUppercase = m_clientID;
+        std::transform(clientIDUppercase.begin(), clientIDUppercase.end(), clientIDUppercase.begin(), ::toupper);
+
+        if (const char *retryCacheLoad = std::getenv(("TURRET_" + clientIDUppercase + "_RETRY_CACHE_LOAD").c_str())){
+            m_retryCacheLoad = std::stoi(retryCacheLoad);
+
+            // A cache file path may have been given at setup, but the file may have been created after setup.
+            if (m_retryCacheLoad){
+
+                // a cache filepath was given but the in-memory cache is empty
+                if (!m_cacheFilePath.empty() && !m_cacheLoaded){
+                    loadCache();
+                }
+            }
+        }
+
 
         std::string query = a_query;
 


### PR DESCRIPTION
… controlled by new env var TURRET_${CLIENT_ID}_RETRY_CACHE_LOAD